### PR TITLE
File client responsible for cloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,6 @@ Base url : `/file/wfm`
 ## Supported storage engines
 
 By default file module would store files in filesystem temporary folder.
-To enable persistent storage please set `usePersistentStorage` flag to true in [config](./lib/config.js)
-and add [file-storage-module](https://github.com/feedhenry-raincatcher/raincatcher-file-storage) to your application.
-
 
 ### AWS S3 storage
 
@@ -123,7 +120,7 @@ var storageConfig = {
     bucket: "raincatcher-files"
   }
 }
-require('fh-wfm-file-storage/lib/cloud')(mediator, storageConfig);
+require('fh-wfm-file/lib/cloud')(mediator, storageConfig);
 ```
 
 ### Gridfs MongoDB storage
@@ -137,48 +134,5 @@ var storageConfig = {
     mongoUrl: "mongodb://localhost:27017/files"
   }
 };
-require('fh-wfm-file-storage/lib/cloud')(mediator, storageConfig);
-```
-
-### Topic Subscriptions
-
-Topics are used in file module.
-
-#### wfm:files:create
-
-##### Description
-
-Save file to the storage
-
-##### Example
-
-
-```javascript
-var parameters = {
-   // File namespace (folder)
-   namespace:null,
-   fileName:"test",
-   location: "/tmp/file"
-  //Optional topic unique identifier
-  topicUid: "uniquetopicid"
-}
-
-mediator.publish("wfm:files-store:create", parameters);
-```
-
-#### wfm:files:get
-##### Description
-
-Retrieve file from the storage (BinaryStream)
-
-##### Example
-
-```javascript
-var parameters = {
-  namespace:null,
-  fileName:"test",
-  topicUid: "uniquetopicid"
-}
-
-mediator.publish("wfm:files-store:get", parameters);
+require('fh-wfm-file/lib/cloud')(mediator, storageConfig);
 ```

--- a/README.md
+++ b/README.md
@@ -99,8 +99,86 @@ Base url : `/file/wfm`
 
 ```
 
-## Persistent file storage
+## Supported storage engines
 
 By default file module would store files in filesystem temporary folder.
-To enable persistent storage please set `usePersistentStorage` flag to true in [config](./lib/config.js) 
+To enable persistent storage please set `usePersistentStorage` flag to true in [config](./lib/config.js)
 and add [file-storage-module](https://github.com/feedhenry-raincatcher/raincatcher-file-storage) to your application.
+
+
+### AWS S3 storage
+
+Allows to store files in AWS S3 buckets.
+
+Options:
+
+```
+var storageConfig = {
+  s3: {
+    s3Options: {
+      accessKeyId: process.env.AWS_S3_ACCESS_KEY,
+      secretAccessKey: process.env.AWS_S3_ACCESS_KEY_SECRET,
+      region: process.env.AWS_S3_REGION
+    },
+    bucket: "raincatcher-files"
+  }
+}
+require('fh-wfm-file-storage/lib/cloud')(mediator, storageConfig);
+```
+
+### Gridfs MongoDB storage
+
+Allows to store file in MongoDB database using Gridfs driver
+
+Options:
+```
+var storageConfig = {
+  gridFs: {
+    mongoUrl: "mongodb://localhost:27017/files"
+  }
+};
+require('fh-wfm-file-storage/lib/cloud')(mediator, storageConfig);
+```
+
+### Topic Subscriptions
+
+Topics are used in file module.
+
+#### wfm:files:create
+
+##### Description
+
+Save file to the storage
+
+##### Example
+
+
+```javascript
+var parameters = {
+   // File namespace (folder)
+   namespace:null,
+   fileName:"test",
+   location: "/tmp/file"
+  //Optional topic unique identifier
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:files-store:create", parameters);
+```
+
+#### wfm:files:get
+##### Description
+
+Retrieve file from the storage (BinaryStream)
+
+##### Example
+
+```javascript
+var parameters = {
+  namespace:null,
+  fileName:"test",
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:files-store:get", parameters);
+```

--- a/lib/client/file-client/FileClient.js
+++ b/lib/client/file-client/FileClient.js
@@ -12,7 +12,7 @@ var $fh;
  * @param {object} fhSdk
  * @constructor
  */
-var FileClient = function FileClient(config, fhSdk){
+var FileClient = function FileClient(config, fhSdk) {
   $fh = fhSdk;
 };
 
@@ -49,10 +49,7 @@ FileClient.prototype.init = function() {
 FileClient.prototype.list = function(userId) {
   var url = !userId ? config.apiPath + '/all' : config.apiPath + '/owner/' + userId;
   var deferred = q.defer();
-  $fh.cloud({
-      path: url,
-      method: 'get'
-    },
+  $fh.cloud({ path: url, method: 'get' },
     function(res) {
       deferred.resolve(res);
     },
@@ -72,12 +69,12 @@ FileClient.prototype.list = function(userId) {
  * @param file {userId, fileURI, options, dataUrl}
  * @returns {*}
  */
-FileClient.prototype.createFile = function(file){
-  if(file.fileURI && file.options){
-    return this.uploadFile(file.userId, file.fileURI, file.options)
-  }else if(file.dataUrl){
-    return this.uploadDataUrl(file.userId, file.dataUrl)
-  }else{
+FileClient.prototype.createFile = function(file) {
+  if (file.fileURI && file.options) {
+    return this.uploadFile(file.userId, file.fileURI, file.options);
+  } else if (file.dataUrl) {
+    return this.uploadDataUrl(file.userId, file.dataUrl);
+  } else {
     return q.reject('Missing required fields for file object ', file);
   }
 };

--- a/lib/client/file-client/index.js
+++ b/lib/client/file-client/index.js
@@ -2,18 +2,15 @@ var FileClient = require('./FileClient');
 var manager;
 
 /**
- *
  * Initialising the FileClient
  *
  * @param config
  * @returns {WorkflowMediatorService}
  */
 module.exports = function(config, $fh) {
-  
   //If there is already a manager, use this
   if (!manager) {
     manager = new FileClient(config, $fh);
   }
-  
   return manager;
 };

--- a/lib/cloud/index.js
+++ b/lib/cloud/index.js
@@ -4,11 +4,18 @@ var express = require('express');
 var config = require('../config');
 var uuid = require('uuid-js');
 var fileService = require('./services/fileService');
-var _ = require("lodash");
+var StorageEngine = require("./storage/index");
 
-function initRouter(mediatorService) {
-  var router = express.Router()
-  
+/**
+ * Create router for fileService
+ *
+ * @param {Object} mediatorService  mediator singleton
+ * @param {Object} storageConfiguration  configuration for file storage
+ * @returns router instance of express router
+ */
+function initRouter(mediatorService, storageConfiguration) {
+  var router = express.Router();
+  var storageEngine = StorageEngine(storageConfiguration);
   router.route('/all').get(function(req, res, next) {
     mediatorService.listFilesMetadata().then(function(fileList) {
       res.json(fileList);
@@ -38,14 +45,10 @@ function initRouter(mediatorService) {
       id: uid
     };
     var stream = fileService.parseBase64Stream(req);
-    var streamPromise = fileService.writeStreamToFile(fileMeta, stream);
-    if (config.usePersistentStorage) {
-      streamPromise = streamPromise.then(function() {
-        var location = fileService.filePath(fileMeta.uid);
-        return mediatorService.saveFileToStorage(fileMeta.namespace, fileMeta.uid, location);
-      });
-    }
-    streamPromise.then(function() {
+    fileService.writeStreamToFile(fileMeta, stream).then(function() {
+      var location = fileService.filePath(fileMeta.uid);
+      return storageEngine.writeFile(fileMeta.namespace, fileMeta.uid, location);
+    }).then(function() {
       return mediatorService.createFileMetadata(fileMeta);
     }).then(function() {
       res.json(fileMeta);
@@ -70,15 +73,9 @@ function initRouter(mediatorService) {
     function(req, res, next) {
       var fileMeta = req.fileMeta;
       var location = fileService.filePath(fileMeta.uid);
-      var promise;
-      if (config.usePersistentStorage) {
-        promise = mediatorService.saveFileToStorage(fileMeta.namespace, fileMeta.uid, location).then(function() {
-          return mediatorService.createFileMetadata(fileMeta);
-        });
-      } else {
-        promise = mediatorService.createFileMetadata(fileMeta);
-      }
-      return promise.then(function() {
+      storageEngine.writeFile(fileMeta.namespace, fileMeta.uid, location).then(function() {
+        return mediatorService.createFileMetadata(fileMeta);
+      }).then(function() {
         res.json(fileMeta);
       }).catch(function(err) {
         console.log(err);
@@ -88,23 +85,28 @@ function initRouter(mediatorService) {
   
   router.route('/get/:filename').get(function(req, res) {
     var fileName = req.params.filename;
-    if (config.usePersistentStorage) {
-      var namespace = req.params.namespace;
-      mediatorService.fetchFileFromStorage(namespace, fileName).then(function(buffer) {
+    var namespace = req.params.namespace;
+    storageEngine.streamFile(namespace, fileName).then(function(buffer) {
+      if (buffer) {
         buffer.pipe(res);
-      });
-    } else {
-      res.sendFile(fileService.filePath(fileName));
-    }
+      } else {
+        res.sendFile(fileService.filePath(fileName));
+      }
+    });
   });
   return router;
 }
-
+/**
+ * Main router module. Inits express routes and mount them into router.
+ *
+ * @param mediator
+ * @param app - express app router
+ * @param externalConfig - configuration passed from application
+ */
 module.exports = function(mediator, app, externalConfig) {
-  _.defaults(config, externalConfig);
   fileService.createTemporaryStorageFolder();
   var MediatorService = require("./services/mediatorService.js");
   var mediatorService = new MediatorService(mediator, config);
-  var router = initRouter(mediatorService);
+  var router = initRouter(mediatorService, externalConfig);
   app.use(config.apiPath, router);
 };

--- a/lib/cloud/services/mediatorService.js
+++ b/lib/cloud/services/mediatorService.js
@@ -1,5 +1,4 @@
 var CONSTANTS = require('../../constants');
-var shortid = require('shortid');
 var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
 
 /**
@@ -12,48 +11,8 @@ var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
 function FileMediatorService(mediator, config) {
   this.mediator = mediator;
   this.config = config || {};
-  
-  this.filesStorageTopics = new MediatorTopicUtility(mediator).prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.FILES_STORAGE_ENTITY_NAME);
   this.filesDataTopics = new MediatorTopicUtility(mediator).prefix(this.config.cloudDataTopicPrefix).entity(this.config.datasetId);
 }
-
-/**
- * Get file Stream from storage
- *
- * @param namespace {String} - namespace used to catalog files in different folders/locations.
- * @param fileName {String} - name of the file
- *
- * @returns {Promise} promise
- */
-FileMediatorService.prototype.fetchFileFromStorage = function(namespace, fileName) {
-  var topicUid = shortid.generate();
-  return this.filesStorageTopics.request(CONSTANTS.STORAGE_TOPICS.GET, {
-    namespace: namespace,
-    fileName: fileName,
-    topicUid: topicUid
-  }, {uid: topicUid})
-    .timeout(this.config.topicTimeout || CONSTANTS.TOPIC_TIMEOUT);
-};
-
-/**
- * Store single file in configured storage
- *
- * @param namespace {String} - namespace used to catalog files in different folders/locations.
- * @param fileName {String} - name of the file
- * @param location {String} - location to the file in local filesystem
- *
- * @returns {Promise} promise
- */
-FileMediatorService.prototype.saveFileToStorage = function(namespace, fileName, location) {
-  var topicUid = shortid.generate();
-  return this.filesStorageTopics.request(CONSTANTS.STORAGE_TOPICS.CREATE, {
-    namespace: namespace,
-    fileName: fileName,
-    location: location,
-    topicUid: topicUid
-  }, {uid: topicUid})
-    .timeout(this.config.topicTimeout || CONSTANTS.TOPIC_TIMEOUT);
-};
 
 /**
  * List files metadata for user

--- a/lib/cloud/storage/awsStorage.js
+++ b/lib/cloud/storage/awsStorage.js
@@ -21,16 +21,15 @@ var awsStorage = {
  *
  * @param storageConfiguration configuration that should be passed from client
  *
- * var storageConfig = {
- *   s3: {
- *     s3Options: {
+ * Example:
+ *   {
+ *    s3Options: {
  *       accessKeyId: process.env.AWS_S3_ACCESS_KEY,
  *       secretAccessKey: process.env.AWS_S3_ACCESS_KEY_SECRET,
  *       region: process.env.AWS_S3_REGION
  *     },
  *     bucket: "raincatcher-files"
  *   }
- * }
  */
 function init(storageConfiguration) {
   config = storageConfiguration;
@@ -101,6 +100,9 @@ function streamFile(namespace, fileName) {
 }
 
 function validateConfig() {
+  if (!config.bucket) {
+    throw Error("Invalid configuration for s3 storage: Please specify bucket name");
+  }
   if (!config.s3Options) {
     throw Error("Invalid configuration for s3 storage");
   }

--- a/lib/cloud/storage/awsStorage.js
+++ b/lib/cloud/storage/awsStorage.js
@@ -1,0 +1,123 @@
+var q = require('q');
+var s3 = require('s3');
+var path = require('path');
+var CONSTANTS = require('../../constants');
+
+var config;
+var awsClient;
+
+/**
+ * Storage engine using AWS S3 api to store files
+ * @type {{init: init, writeFile: writeFile, streamFile: streamFile}}
+ */
+var awsStorage = {
+  init: init,
+  writeFile: writeFile,
+  streamFile: streamFile
+};
+
+/**
+ * Init module
+ *
+ * @param storageConfiguration configuration that should be passed from client
+ *
+ * var storageConfig = {
+ *   s3: {
+ *     s3Options: {
+ *       accessKeyId: process.env.AWS_S3_ACCESS_KEY,
+ *       secretAccessKey: process.env.AWS_S3_ACCESS_KEY_SECRET,
+ *       region: process.env.AWS_S3_REGION
+ *     },
+ *     bucket: "raincatcher-files"
+ *   }
+ * }
+ */
+function init(storageConfiguration) {
+  config = storageConfiguration;
+  validateConfig();
+  awsClient = s3.createClient(config);
+}
+/**
+ * Write file to the storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ * @param {string} fileLocation - local filesystem location to the file
+ */
+function writeFile(namespace, fileName, fileLocation) {
+  var file;
+  if (namespace) {
+    file = path.join(namespace, fileName);
+  } else {
+    file = fileName;
+  }
+  var params = {
+    localFile: fileLocation,
+    ACL: CONSTANTS.AWS_BUCKET_PERMISSIONS,
+    s3Params: {
+      Bucket: config.bucket,
+      Key: file
+    }
+  };
+  var deferred = q.defer();
+  var uploader = awsClient.uploadFile(params);
+  uploader.on('error', function(err) {
+    console.log(err);
+    deferred.reject(err.stack);
+  });
+  uploader.on('end', function() {
+    deferred.resolve(fileName);
+  });
+  return deferred.promise;
+}
+
+/**
+ * Retrieve file stream from storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ *
+ */
+function streamFile(namespace, fileName) {
+  var file;
+  if (namespace) {
+    file = path.join(namespace, fileName);
+  } else {
+    file = fileName;
+  }
+  var deferred = q.defer();
+  var paramsStream = {
+    Bucket: config.bucket,
+    Key: file
+  };
+  try {
+    var stream = awsClient.downloadStream(paramsStream);
+    deferred.resolve(stream);
+  } catch (error) {
+    console.log(error);
+    deferred.reject(error);
+  }
+  return deferred.promise;
+}
+
+function validateConfig() {
+  if (!config.s3Options) {
+    throw Error("Invalid configuration for s3 storage");
+  }
+  if (!config.s3Options.accessKeyId) {
+    throw Error("Invalid configuration for s3 storage: Access Key missing");
+  }
+  if (!config.s3Options.secretAccessKey) {
+    throw Error("Invalid configuration for s3 storage: secretAccessKeymissing");
+  }
+  if (!config.s3Options.region) {
+    throw Error("Invalid configuration for s3 storage: region missing");
+  }
+}
+
+/**
+ * Implements storage interface for AWS S3 storage
+ *
+ * @type {{init: function, writeFile: function, streamFile: function}}
+ */
+module.exports = awsStorage;

--- a/lib/cloud/storage/gridfsStorage.js
+++ b/lib/cloud/storage/gridfsStorage.js
@@ -1,0 +1,101 @@
+var q = require('q');
+var fs = require('fs');
+var mongo = require('mongodb');
+var Grid = require('gridfs-stream');
+var MongoClient = require('mongodb').MongoClient;
+
+var gfsPromise;
+
+/**
+ * Storage engine that utilizes gridfs mongodb connection to store files
+ */
+var gridFsStorage = {
+  init: init,
+  writeFile: writeFile,
+  streamFile: streamFile
+};
+
+/**
+ * Init module
+ *
+ * @param storageConfiguration configuration that should be passed from client
+ *
+ * var storageConfig = {
+ *  bucket: "raincatcher-files"
+ * }
+ */
+function init(storageConfiguration) {
+  var config = storageConfiguration;
+  if (!config || !config.mongoUrl) {
+    throw Error("Missing mongoUrl parameter for GridFs storage");
+  }
+  var deferred = q.defer();
+  MongoClient.connect(config.mongoUrl, function(err, connection) {
+    if (err) {
+      console.log("Cannot connect to mongodb server. Gridfs storage will be disabled");
+      return deferred.reject(err);
+    }
+    var gfs = Grid(connection, mongo);
+    deferred.resolve(gfs);
+  });
+  gfsPromise = deferred.promise;
+}
+
+/**
+ * Write file to the storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ * @param {string} fileLocation - local filesystem location to the file
+ */
+function writeFile(namespace, fileName, fileLocation) {
+  if (!gfsPromise) {
+    return;
+  }
+  return gfsPromise.then(function(gfs) {
+    var deferred = q.defer();
+    var options = {
+      filename: fileName
+    };
+    if (namespace) {
+      options.root = namespace;
+    }
+    var writeStream = gfs.createWriteStream(options);
+    writeStream.on('error', function(err) {
+      console.log('An error occurred!', err);
+      deferred.reject(err);
+    });
+    writeStream.on('close', function(file) {
+      deferred.resolve(file);
+    });
+    fs.createReadStream(fileLocation).pipe(writeStream);
+    return deferred.promise;
+  });
+}
+
+/**
+ * Retrieve file stream from storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ *
+ */
+function streamFile(namespace, fileName) {
+  return gfsPromise.then(function(gfs) {
+    var deferred = q.defer();
+    var options = {
+      filename: fileName
+    };
+    if (namespace) {
+      options.root = namespace;
+    }
+    var readstream = gfs.createReadStream(options);
+    readstream.on('error', function(err) {
+      console.log('An error occurred when reading file from gridfs!', err);
+    });
+    deferred.resolve(readstream);
+    return deferred.promise;
+  });
+}
+
+module.exports = gridFsStorage;

--- a/lib/cloud/storage/gridfsStorage.js
+++ b/lib/cloud/storage/gridfsStorage.js
@@ -19,10 +19,10 @@ var gridFsStorage = {
  * Init module
  *
  * @param storageConfiguration configuration that should be passed from client
- *
- * var storageConfig = {
- *  bucket: "raincatcher-files"
- * }
+ * Example:
+ *  {
+ *    mongoUrl: "mongodb://localhost:27017/files"
+ *  }
  */
 function init(storageConfiguration) {
   var config = storageConfiguration;

--- a/lib/cloud/storage/index.js
+++ b/lib/cloud/storage/index.js
@@ -1,0 +1,31 @@
+var gridfsStorage = require('./gridfsStorage');
+var s3Storage = require('./awsStorage');
+var tempStorage = require('./tempStorage');
+var client;
+
+/**
+ *
+ * Initialising the storage engine
+ *
+ * @param config
+ * @returns {StorageEngine} storageObject
+ *
+ * function init(storageConfiguration)
+ * function writeFile(namespace, fileName, fileLocation)
+ * function streamFile(namespace, fileName)
+ */
+module.exports = function(config) {
+  if (!client) {
+    if (config.s3) {
+      client = s3Storage;
+      client.init(config.s3);
+    } else if (config.gridFs) {
+      client = gridfsStorage;
+      client.init(config.gridFs);
+    } else {
+      client = tempStorage;
+      client.init();
+    }
+  }
+  return client;
+};

--- a/lib/cloud/storage/tempStorage.js
+++ b/lib/cloud/storage/tempStorage.js
@@ -1,0 +1,53 @@
+var q = require('q');
+
+/**
+ * Interface for storage engines used when no persistent storage configuration is passed from client
+ * @type {{init: init, writeFile: writeFile, streamFile: streamFile}}
+ */
+var tempStorageInterface = {
+  init: init,
+  writeFile: writeFile,
+  streamFile: streamFile
+};
+
+
+/**
+ * Init module
+ *
+ * @param storageConfiguration configuration that should be passed from client
+ *
+ * var storageConfig = {
+ *  bucket: "raincatcher-files"
+ * }
+ */
+function init() {
+}
+
+/**
+ * Write file to the storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ * @param {string} fileLocation - local filesystem location to the file
+ */
+function writeFile(namespace, fileName, fileLocation) {
+  var deferred = q.defer();
+  // File is already written by middleware
+  deferred.resolve(fileLocation);
+  return deferred.promise;
+}
+
+/**
+ * Retrieve file stream from storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ *
+ */
+function streamFile() {
+  var deferred = q.defer();
+  deferred.resolve();
+  return deferred.promise;
+}
+
+module.exports = tempStorageInterface;

--- a/lib/cloud/storage/tempStorage.js
+++ b/lib/cloud/storage/tempStorage.js
@@ -13,12 +13,6 @@ var tempStorageInterface = {
 
 /**
  * Init module
- *
- * @param storageConfiguration configuration that should be passed from client
- *
- * var storageConfig = {
- *  bucket: "raincatcher-files"
- * }
  */
 function init() {
 }
@@ -42,7 +36,6 @@ function writeFile(namespace, fileName, fileLocation) {
  *
  * @param {string} namespace - location (folder) used to place saved file.
  * @param {string} fileName - filename that should be unique within namespace
- *
  */
 function streamFile() {
   var deferred = q.defer();

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,7 +1,6 @@
 module.exports = {
   TOPIC_PREFIX: "wfm",
   FILES_ENTITY_NAME: "files",
-  FILES_STORAGE_ENTITY_NAME: "files-store",
   TOPIC_SEPARATOR: ":",
   ERROR_PREFIX: "error",
   DONE_PREFIX: "done",

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -12,5 +12,6 @@ module.exports = {
   STORAGE_TOPICS: {
     CREATE: "create",
     GET: "get"
-  }
+  },
+  AWS_BUCKET_PERMISSIONS: 'authenticated-read'
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-file",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A WFM module providing client and backend for file support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "q": "1.4.1",
     "shortid": "^2.2.8",
     "through2": "2.0.1",
-    "uuid-js": "0.7.5"
+    "uuid-js": "0.7.5",
+    "gridfs-stream": "^1.1.1",
+    "mongodb": "^2.2.25",
+    "s3": "^4.4.0"
   },
   "devDependencies": {
-    "fh-wfm-mediator": "0.3.1",
     "grunt": "0.4.5",
     "grunt-eslint": "18.1.0",
     "grunt-mochify": "^0.3.0",


### PR DESCRIPTION
## Motivation

Move logic from storage module into file for better unification as file would be always responsible to storage. Moving logic would allow us to simplify interaction. 
There was no logic and code changes done as part of this work. Just minimal refactoring was required to fit into new file module structure. 

## Verification

Verification should involve setting up s3 or gridfs storage module and checking if images are saved.

See also: https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud/pull/86

ping @col1985 